### PR TITLE
remove version from pyside2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ here = path.abspath(path.dirname(__file__))
 extras_require = {
     'dev': ['sphinx', 'pytest'],
     'cli': ['colorama', 'graphviz', 'tqdm', 'mwclient', 'mwparserfromhell', 'rapidfuzz'],
-    'ui': ['pyside2==5.14.0'],
+    'ui': ['pyside2'],
     'ui-extra': ['PyOpenGL'],
 }
 


### PR DESCRIPTION
pip can't find this specific version of pyside2 when using python 3.9.2. Removing the specific version allows it to install and run successfully using pyside2 5.15.